### PR TITLE
Define timespec_get on Mojave as well as Catalina

### DIFF
--- a/Formula/seabolt.rb
+++ b/Formula/seabolt.rb
@@ -8,7 +8,7 @@ class Seabolt < Formula
   depends_on "pkg-config"
   depends_on "openssl" => [:build, :test]
 
-  patch :DATA  if MacOS.version == :catalina
+  patch :DATA  if MacOS.version == :mojave || MacOS.version == :catalina
 
   def install
     system "mkdir", "build"


### PR DESCRIPTION
Some people may still be using Mojave and we want to make sure the `timespec_get` patch gets applied there as well.