### PR TITLE
Define timespec_get on Big Sur

### DIFF
--- a/Formula/seabolt.rb
+++ b/Formula/seabolt.rb
@@ -8,7 +8,7 @@ class Seabolt < Formula
   depends_on "pkg-config"
   depends_on "openssl" => [:build, :test]
 
-  patch :DATA  if MacOS.version == :mojave || MacOS.version == :catalina
+  patch :DATA  if MacOS.version == :big_sur || MacOS.version == :mojave || MacOS.version == :catalina
 
   def install
     system "mkdir", "build"


### PR DESCRIPTION
This is to update the `timespec_get` patch to support MacOS 11 (Big Sur), currently in public beta.